### PR TITLE
Use backports.lzma on Windows and package the license file

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,6 +44,7 @@ test:
 about:
   home: https://github.com/alimanfoo/numcodecs
   license: MIT
+  license_file: LICENSE
   summary: A Python package providing buffer compression and transformation codecs for use in data storage and communication applications.
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   script:
     - export DISABLE_NUMCODECS_AVX2=""  # [unix]
     - set DISABLE_NUMCODECS_AVX2=""  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - python
     - numpy
     - msgpack-python
-    - backports.lzma  # [py27 and unix]
+    - backports.lzma  # [py27]
 
 test:
   requires:


### PR DESCRIPTION
Now that `backports.lzma` is built for Windows too, require it for all Python 2.7 builds of `numcodecs`. Also make sure that `numcodecs`'s license file is packaged. Bump build number to `1` to generate new packages with these changes.